### PR TITLE
Draft: Create silu_mul Task and Add ut 

### DIFF
--- a/include/mirage/persistent_kernel/tasks/blackwell/silu_mul_sm100.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/silu_mul_sm100.cuh
@@ -1,0 +1,31 @@
+ #pragma once
+ #include "tasks/common/common_header.cuh"
+ namespace kernel {
+ 
+ template <typename T>
+ __device__ __forceinline__ void silu_mul_sm100_task_impl(T const *w1x_w3x, // Shape: B, TopK, 2*Inter, compact
+                                                    T *output_ptr, // Shape: B, TopK, Inter
+                                                int batch_size,
+                                                int topk_size,
+                                                int inter_size) { 
+
+    // Each thread processes output_token_per_thread tokens
+
+    int out_size = batch_size * topk_size * inter_size;
+
+    for (int i = threadIdx.x; i < out_size; i += blockDim.x) {
+        // Get w1x_w3x[b, topk, :]
+        int batch_idx = i / (TopK_SIZE * INTER_SIZE);
+        int topk_idx = (i / INTER_SIZE) % TopK_SIZE;
+        int inter_idx = i % INTER_SIZE;
+        int w1_index = batch_idx * TopK_SIZE * 2 * INTER_SIZE + topk_idx * 2 * INTER_SIZE + inter_idx;
+        T w1x = w1x_w3x[w1_index];
+        T w3x = w1x_w3x[w1_index + INTER_SIZE];
+
+        // SiLU(w1x) * w3x
+        T out = w1x / (1.0f + expf(-w1x)) *w3x;
+        output_ptr[i] = out;
+    }
+ 
+ } // namespace kernel
+ 

--- a/include/mirage/persistent_kernel/tasks/blackwell/silu_mul_sm100.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/silu_mul_sm100.cuh
@@ -15,12 +15,12 @@
 
     for (int i = threadIdx.x; i < out_size; i += blockDim.x) {
         // Get w1x_w3x[b, topk, :]
-        int batch_idx = i / (TopK_SIZE * INTER_SIZE);
-        int topk_idx = (i / INTER_SIZE) % TopK_SIZE;
-        int inter_idx = i % INTER_SIZE;
-        int w1_index = batch_idx * TopK_SIZE * 2 * INTER_SIZE + topk_idx * 2 * INTER_SIZE + inter_idx;
+        int batch_idx = i / (topk_size * inter_size);
+        int topk_idx = (i / inter_size) % topk_size;
+        int inter_idx = i % inter_size;
+        int w1_index = batch_idx * topk_size * 2 * inter_size + topk_idx * 2 * inter_size + inter_idx;
         T w1x = w1x_w3x[w1_index];
-        T w3x = w1x_w3x[w1_index + INTER_SIZE];
+        T w3x = w1x_w3x[w1_index + inter_size];
 
         // SiLU(w1x) * w3x
         T out = w1x / (1.0f + expf(-w1x)) *w3x;

--- a/include/mirage/persistent_kernel/tasks/blackwell/silu_mul_sm100.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/silu_mul_sm100.cuh
@@ -3,13 +3,16 @@
  namespace kernel {
  
  template <typename T>
- __device__ __forceinline__ void silu_mul_sm100_task_impl(T const *w1x_w3x, // Shape: B, TopK, 2*Inter, compact
-                                                    T *output_ptr, // Shape: B, TopK, Inter
+ __device__ __forceinline__ void silu_mul_sm100_task_impl(void const *w1x_w3x_ptr, // Shape: B, TopK, 2*Inter, compact
+                                                    void *output_ptr, // Shape: B, TopK, Inter
                                                 int batch_size,
                                                 int topk_size,
                                                 int inter_size) { 
 
     // Each thread processes output_token_per_thread tokens
+
+    const T* w1x_w3x = static_cast<const T*>(w1x_w3x_ptr);
+    T* output = static_cast<T*>(output_ptr);
 
     int out_size = batch_size * topk_size * inter_size;
 

--- a/include/mirage/persistent_kernel/tasks/blackwell/task_header.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/task_header.cuh
@@ -16,3 +16,4 @@
 #include "linear_sm100_mpk.cuh"
 #include "w13_linear_sm100.cuh"
 #include "topk_softmax_sm100.cuh"
+#include "silu_mul_sm100.cuh"

--- a/tests/runtime_python/blackwell/sm100_moe/runtime_kernel_wrapper_sm100.cu
+++ b/tests/runtime_python/blackwell/sm100_moe/runtime_kernel_wrapper_sm100.cu
@@ -339,8 +339,41 @@ void w13_linear_sm100_kernel(torch::Tensor input,
   }
 }
 
+// w1x * w3x shape: B, K, 2*Iter (The result of [w1,w3] * x)
+// output shape: B, K, Iter (SiLU(w1x) * w3x)
+void silu_mul_sm100_kernel(torch::Tensor w1x_w3x,
+                     torch::Tensor output) {
+  assert(w1x_w3x.size(1) == output.size(1));
+  assert(w1x_w3x.size(2) == 2 * output.size(2));
+
+  void *output_ptr = output.data_ptr();
+  void *w1x_w3x_ptr = w1x_w3x.data_ptr();
+
+  int batch_size = output.size(0);
+  int topk_size = output.size(1);
+  int inter_size = output.size(2);
+
+  // output numel
+  int numel = output.numel();
+
+  constexpr int ELEMENT_PER_THREAD = 8;
+  constexpr int BLOCK_SIZE = 256;
+
+  int grid_x = (numel + BLOCK_SIZE * ELEMENT_PER_THREAD - 1) / (BLOCK_SIZE * ELEMENT_PER_THREAD);
+  // Same as the kernel in runtime_kernel_wrapper.cu
+  dim3 grid_dim(grid_x, 1, 1);
+  dim3 block_dim(BLOCK_SIZE, 1, 1);
+
+  kernel::silu_mul_sm100_task_impl<bfloat16><<<grid_dim,block_dim>>>(w1x_w3x_ptr, output_ptr, batch_size, topk_size, inter_size);
+  cudaError_t err = cudaDeviceSynchronize();
+  if (err != cudaSuccess) {
+    printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));
+  }
+}
+
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("topk_softmax_sm100", &topk_softmax_sm100_kernel, "TopK Softmax fused SM100");
   m.def("w13_linear_sm100", &w13_linear_sm100_kernel, "W13 Linear kernel SM100");
+  m.def("silu_mul_sm100", &silu_mul_sm100_kernel, "SiLU multiplication kernel SM100");
 }

--- a/tests/runtime_python/blackwell/sm100_moe/runtime_kernel_wrapper_sm100.cu
+++ b/tests/runtime_python/blackwell/sm100_moe/runtime_kernel_wrapper_sm100.cu
@@ -12,12 +12,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+ // Put torch/extension.h first to avoid conflicts with pybind11
+#include <torch/extension.h>
+
 #include "runtime_header.h"
 #include "blackwell/task_header.cuh"
 #include "hopper/tma_2d.cuh"
+#include "common/common_header.cuh"
 #include "tma.cuh"
 #include <cuda_runtime.h>
-#include <torch/extension.h>
+
 
 #include <iostream>
 #include <cstdio>
@@ -339,6 +343,18 @@ void w13_linear_sm100_kernel(torch::Tensor input,
   }
 }
 
+// silu_mul_sm100
+template <typename T>
+__global__ __launch_bounds__(256,1) void silu_mul_sm100_wrapper(
+    void const *w1x_w3x_ptr, // Shape: B, TopK, 2*Inter, compact
+    ️void *output_ptr, // Shape: B, TopK, Inter
+    int batch_size,
+    int topk_size,
+    int inter_size) {
+
+  kernel::silu_mul_sm100_task_impl<T>(w1x_w3x_ptr, output_ptr, batch_size, topk_size, inter_size);
+}
+
 // w1x * w3x shape: B, K, 2*Iter (The result of [w1,w3] * x)
 // output shape: B, K, Iter (SiLU(w1x) * w3x)
 void silu_mul_sm100_kernel(torch::Tensor w1x_w3x,
@@ -364,7 +380,7 @@ void silu_mul_sm100_kernel(torch::Tensor w1x_w3x,
   dim3 grid_dim(grid_x, 1, 1);
   dim3 block_dim(BLOCK_SIZE, 1, 1);
 
-  kernel::silu_mul_sm100_task_impl<bfloat16><<<grid_dim,block_dim>>>(w1x_w3x_ptr, output_ptr, batch_size, topk_size, inter_size);
+  silu_mul_sm100_wrapper<bfloat16><<<grid_dim,block_dim>>>(w1x_w3x_ptr, output_ptr, batch_size, topk_size, inter_size);
   cudaError_t err = cudaDeviceSynchronize();
   if (err != cudaSuccess) {
     printf("CUDA kernel launch error: %s\n", cudaGetErrorString(err));

--- a/tests/runtime_python/blackwell/sm100_moe/setup.py
+++ b/tests/runtime_python/blackwell/sm100_moe/setup.py
@@ -29,12 +29,14 @@ setup(
             depends=[
                 os.path.join(this_dir, '../../../../include/mirage/persistent_kernel/tasks/blackwell/topk_softmax_sm100.cuh'),
                 os.path.join(this_dir, '../../../../include/mirage/persistent_kernel/tasks/blackwell/w13_linear_sm100_mpk.cuh'),
+                os.path.join(this_dir, '../../../../include/mirage/persistent_kernel/tasks/blackwell/silu_mul_sm100.cuh'),
                 os.path.join(this_dir, '../../../../include/mirage/persistent_kernel/tasks/blackwell/utils.cuh'),
             ],
             define_macros=macros,
             include_dirs=[
                 os.path.join(this_dir, '../../../../include/mirage/persistent_kernel/'),
                 os.path.join(this_dir, '../../../../include/mirage/persistent_kernel/tasks/'),
+                os.path.join(this_dir, '../../../../include/mirage/persistent_kernel/tasks/common/'),
                 os.path.join(this_dir, '../../../../include'),
                 os.path.join(this_dir, '../../../../deps/cutlass/include'),
                 os.path.join(this_dir, '../../../../deps/cutlass/tools/util/include'),

--- a/tests/runtime_python/blackwell/sm100_moe/test_silu_mul.py
+++ b/tests/runtime_python/blackwell/sm100_moe/test_silu_mul.py
@@ -1,0 +1,41 @@
+import torch
+import runtime_kernel_blackwell
+
+torch.set_printoptions(sci_mode=False, profile="full")
+# torch.set_printoptions(sci_mode=False)
+
+g = torch.Generator(device="cuda").manual_seed(1234)
+
+iter_dim = 4096
+top_ks = [64]
+batch_sizes = [32]
+
+has_residual = True
+
+for top_k in top_ks:
+    for batch_size in batch_sizes:
+        print(
+            f"\n=== Testing batch_size = {batch_size} ==="
+        )
+
+        w1x_w3x = torch.randn((batch_size, top_k, iter_dim), device="cuda", dtype=torch.bfloat16)
+        output = torch.empty(batch_size, top_k, iter_dim, device="cuda", dtype=torch.bfloat16)
+
+
+        runtime_kernel_blackwell.linear_sm100_mpk(w1x_w3x, output) # with residual and swapAB
+
+
+        with torch.no_grad():
+            w1x = w1x_w3x[:,:,:iter_dim]
+            w3x = w1x_w3x[:,:,iter_dim:]
+
+            # SwiLU multiplication
+            torch_out = torch.nn.functional.silu(w1x) * w3x
+
+        torch.testing.assert_close(
+            output,
+            torch_out,
+            rtol=1e-2,
+            atol=1e-2,
+        )
+        print("Test passed!")


### PR DESCRIPTION
**Description of changes:**
Add implementation of silu_mul, which takes in `[w1x|w3x]` result from previous task and perform, `silu(w1x)*w3x`, where `*` is the elementwise prod.

TODO: Add benchmark, use vectorized load if needed.

