### PR TITLE
modify topk softmax to expose new output

### DIFF
--- a/include/mirage/persistent_kernel/tasks/blackwell/topk_softmax_sm100.cuh
+++ b/include/mirage/persistent_kernel/tasks/blackwell/topk_softmax_sm100.cuh
@@ -74,7 +74,8 @@ __device__ __forceinline__ void topk_softmax_task_impl(
     void *__restrict__ mpk_routing_indices_ptr, // [NUM_EXPERTS, num_rows] laid out
                                            // as expert-major: expert * num_rows
                                            // + row
-    void *__restrict__ mpk_expert_mask_ptr,     // [NUM_EXPERTS]
+    void *__restrict__ mpk_active_expert_ids_ptr, // [NUM_EXPERTS]
+    void *__restrict__ mpk_num_active_experts_ptr, // [1]
     int const start_expert,
     int const end_expert,
     bool const renormalize) {
@@ -82,17 +83,21 @@ __device__ __forceinline__ void topk_softmax_task_impl(
   T *input = static_cast<T *>(input_ptr);
   float *output = static_cast<float *>(output_ptr);
   int *mpk_routing_indices = static_cast<int *>(mpk_routing_indices_ptr);
-  int *mpk_expert_mask = static_cast<int *>(mpk_expert_mask_ptr);
-  // initialize mpk_routing_indices and mpk_expert_mask to zero
-  for(int expert = start_expert + threadIdx.x; expert < end_expert; expert += blockDim.x) {
+  int *mpk_active_expert_ids = static_cast<int *>(mpk_active_expert_ids_ptr);
+  int *mpk_num_active_experts = static_cast<int *>(mpk_num_active_experts_ptr);
+  // initialize routing indices to 0; active-id marks to -1; count to 0
+  for (int expert = start_expert + threadIdx.x; expert < end_expert; expert += blockDim.x) {
     if (mpk_routing_indices != nullptr) {
       for (int row = 0; row < num_rows; ++row) {
         mpk_routing_indices[expert * num_rows + row] = 0;
       }
     }
-    if (mpk_expert_mask != nullptr) {
-      mpk_expert_mask[expert] = 0;
+    if (mpk_active_expert_ids != nullptr) {
+      mpk_active_expert_ids[expert - start_expert] = -1;
     }
+  }
+  if (threadIdx.x == 0 && mpk_num_active_experts != nullptr) {
+    *mpk_num_active_experts = 0;
   }
   __syncthreads();
   // Compile-time checks
@@ -243,16 +248,15 @@ __device__ __forceinline__ void topk_softmax_task_impl(
         //     should_process_row ? (expert - start_expert) : NUM_EXPERTS;
         row_sum_for_renormalize += max_val;
         // Optionally populate MPK routing structures
-        if (should_process_row && mpk_routing_indices != nullptr &&
-            mpk_expert_mask != nullptr) {
+        if (should_process_row && mpk_routing_indices != nullptr) {
           int const local_expert = expert - start_expert;
           // Write 1-based rank into routing indices; stride by num_rows per
           // expert
           mpk_routing_indices[local_expert * num_rows + thread_row] = k_idx + 1;
-          // // Mark expert as active (idempotent). Atomic to avoid races across
-          // rows. atomicExch(&mpk_expert_mask[local_expert], 1); // race
-          // condition might be okay here
-          mpk_expert_mask[local_expert] = 1;
+          // Sparse mark expert as active; idempotent without atomics
+          if (mpk_active_expert_ids != nullptr) {
+            mpk_active_expert_ids[local_expert] = local_expert;
+          }
         }
       }
 
@@ -275,6 +279,18 @@ __device__ __forceinline__ void topk_softmax_task_impl(
       for (int k_idx = 0; k_idx < k; ++k_idx) {
         int const out_idx = k * thread_row + k_idx;
         output[out_idx] = output[out_idx] * inv;
+      }
+    }
+  }
+  __syncthreads();
+  // Compact marks into a dense list and count
+  if (mpk_active_expert_ids != nullptr && mpk_num_active_experts != nullptr) {
+    for (int expert = start_expert + threadIdx.x; expert < end_expert; expert += blockDim.x) {
+      int const local_expert = expert - start_expert;
+      int const mark = mpk_active_expert_ids[local_expert];
+      if (mark >= 0) {
+        int const pos = atomicAdd(mpk_num_active_experts, 1);
+        mpk_active_expert_ids[pos] = expert;
       }
     }
   }

--- a/tests/runtime_python/blackwell/sm100_moe/runtime_kernel_wrapper_sm100.cu
+++ b/tests/runtime_python/blackwell/sm100_moe/runtime_kernel_wrapper_sm100.cu
@@ -42,10 +42,11 @@ using bfloat16 = cute::bfloat16_t;
 
 template <typename T, int EXPERTS, int BYTES_PER_LDG>
 __global__ __launch_bounds__(256) void topk_softmax_kernel(
-    void const *__restrict__ gating_output,
+    void *__restrict__ gating_output,
     void *__restrict__ topk_weights,
     void *__restrict__ mpk_routing_indices, // [EXPERTS, num_rows] expert-major
-    void *__restrict__ mpk_expert_mask,     // [EXPERTS]
+    void *__restrict__ mpk_active_expert_ids,     // [EXPERTS]
+    void *__restrict__ mpk_num_active_experts,    // [1]
     int num_rows,
     int k,
     bool renormalize) {
@@ -59,7 +60,8 @@ __global__ __launch_bounds__(256) void topk_softmax_kernel(
       num_rows,
       k,
       mpk_routing_indices,
-      mpk_expert_mask,
+      mpk_active_expert_ids,
+      mpk_num_active_experts,
       /*start_expert=*/0,
       /*end_expert=*/EXPERTS,
       renormalize);
@@ -70,7 +72,8 @@ __global__ __launch_bounds__(256) void topk_softmax_kernel(
 void topk_softmax_sm100_kernel(torch::Tensor gating_output,
                                torch::Tensor topk_weights,
                                torch::Tensor mpk_routing_indices,
-                               torch::Tensor mpk_expert_mask) {
+                               torch::Tensor mpk_active_expert_ids,
+                               torch::Tensor mpk_num_active_experts) {
 
   int const BATCH_SIZE = static_cast<int>(gating_output.size(0));
   int const OUTPUT_SIZE = static_cast<int>(gating_output.size(1));
@@ -80,12 +83,14 @@ void topk_softmax_sm100_kernel(torch::Tensor gating_output,
          topk_weights.size(1) == NUM_TOPK);
   assert(mpk_routing_indices.size(0) == OUTPUT_SIZE &&
          mpk_routing_indices.size(1) == BATCH_SIZE);
-  assert(mpk_expert_mask.size(0) == OUTPUT_SIZE);
+  assert(mpk_active_expert_ids.size(0) == OUTPUT_SIZE);
+  assert(mpk_num_active_experts.numel() == 1);
 
   void *gating_output_ptr = gating_output.data_ptr();
   void *topk_weights_ptr = topk_weights.data_ptr();
   void *mpk_routing_indices_ptr = mpk_routing_indices.data_ptr();
-  void *mpk_expert_mask_ptr = mpk_expert_mask.data_ptr();
+  void *mpk_active_expert_ids_ptr = mpk_active_expert_ids.data_ptr();
+  void *mpk_num_active_experts_ptr = mpk_num_active_experts.data_ptr();
 
   // launch grid using 256-thread blocks
   auto launch = [&](auto experts_ct) {
@@ -100,7 +105,8 @@ void topk_softmax_sm100_kernel(torch::Tensor gating_output,
             gating_output_ptr,
             topk_weights_ptr,
             mpk_routing_indices_ptr,
-            mpk_expert_mask_ptr,
+            mpk_active_expert_ids_ptr,
+            mpk_num_active_experts_ptr,
             BATCH_SIZE,
             NUM_TOPK,
             /*renormalize=*/true);

--- a/tests/runtime_python/blackwell/sm100_moe/test_gate_topk.py
+++ b/tests/runtime_python/blackwell/sm100_moe/test_gate_topk.py
@@ -23,13 +23,17 @@ for num_expert in num_experts_list:
 
         topk_weights = torch.empty(batch_size, num_topk, device="cuda", dtype=torch.float)
         mpk_routing_indices = torch.zeros((num_expert, batch_size), device="cuda", dtype=torch.int32)
-        mpk_expert_mask = torch.zeros((num_expert,), device="cuda", dtype=torch.int32)
+        mpk_active_ids = torch.empty((num_expert,), device="cuda", dtype=torch.int32)
+        mpk_num_active = torch.zeros((1,), device="cuda", dtype=torch.int32)
+
+        # Preserve a copy of inputs for reference before kernel mutates input
+        gating_output_ref = gating_output.clone()
 
         # Run fused topk softmax
-        runtime_kernel_blackwell.topk_softmax_sm100(gating_output, topk_weights, mpk_routing_indices, mpk_expert_mask)
+        runtime_kernel_blackwell.topk_softmax_sm100(gating_output, topk_weights, mpk_routing_indices, mpk_active_ids, mpk_num_active)
 
         # Reference: select topk then softmax over those values
-        gating_output_f = gating_output.to(torch.float)
+        gating_output_f = gating_output_ref.to(torch.float)
         norm_gating_output = gating_output_f - gating_output_f.amax(dim=1, keepdim=True)
         torch_softmax = F.softmax(norm_gating_output, dim=1, dtype=torch.float)
         # print("torch_softmax:", torch_softmax)
@@ -58,8 +62,17 @@ for num_expert in num_experts_list:
             rtol=1e-2,
             atol=1e-2,
         )
+        # Reconstruct mask from active ids output and print diagnostics
+        num_active = int(mpk_num_active.item())
+        print(f"Active experts: {num_active}")
+        if num_active > 0:
+            print(f"Active expert IDs: {mpk_active_ids[:num_active].cpu().tolist()}")
+        recon_mask = torch.zeros((num_expert,), device="cuda", dtype=torch.int32)
+        if num_active > 0:
+            active_ids = mpk_active_ids[:num_active].to(torch.long)
+            recon_mask.index_fill_(0, active_ids, 1)
         torch.testing.assert_close(
-            mpk_expert_mask,
+            recon_mask,
             torch_expert_mask,
             rtol=1e-2,
             atol=1e-2,


### PR DESCRIPTION
**Description of changes:**
now instead of mask, we expose mpk_active_expert_ids and mpk_num_active_experts to avoid multiple global reads in the following GEMM


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


